### PR TITLE
#166283068 Admin can delete car Ad

### DIFF
--- a/server/controllers/carController.js
+++ b/server/controllers/carController.js
@@ -128,6 +128,25 @@ class CarController {
     }
   }
 
+  static async deleteCarAd(req, res) {
+    const { carId } = req.params;
+    try {
+      for (let i = 0; i < carModel.length; i += 1) {
+        if (carModel[i].id === carId) {
+          carModel.splice(i, 1);
+          return res.status(200).json({
+            status: 204,
+            data: [],
+            message: 'Car Ad deleted successfully',
+          });
+        }
+      }
+      return res.status(404).json({ status: 404, message: `Car with id: ${carId} not found` });
+    } catch (err) {
+      return res.status(500).json({ status: 500, error: 'Internal Server error' });
+    }
+  }
+
 }
 
 export default CarController;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -10,8 +10,8 @@ import OrderController from '../controllers/orderController';
 const router = express.Router();
 
 const { createAccount, loginUser } = AuthController;
-const { validateSignUp, userExists, validateLogin, isTokenValid } = AuthValidator;
-const { createCarAd, updateCarAdStatus, updateCarAdPrice, getACar, getAllCars } = CarController;
+const { validateSignUp, userExists, validateLogin, isTokenValid, isAdmin } = AuthValidator;
+const { createCarAd, updateCarAdStatus, updateCarAdPrice, getACar, getAllCars, deleteCarAd } = CarController;
 const { validateCar, isCarExist, isCarOwner, validateStatus, validatePrice, validateParams } = CarValidator;
 const { validateOrder, isOrderOwner, validateAmount } = OrderValidator;
 const { createOrder, updateOrderPrice } = OrderController;
@@ -28,6 +28,7 @@ router.patch(`${carBaseUrl}/:carId/status`, isTokenValid, isCarExist, isCarOwner
 router.patch(`${carBaseUrl}/:carId/price`, isTokenValid, isCarExist, isCarOwner, validatePrice, updateCarAdPrice);
 router.get(`${carBaseUrl}/:carId`, isTokenValid, getACar);
 router.get(`${carBaseUrl}`, isTokenValid, validateParams, getAllCars);
+router.delete(`${carBaseUrl}/:carId`, isTokenValid, isAdmin, deleteCarAd);
 
 // Order routes
 const orderBaseUrl = '/api/v1/order';


### PR DESCRIPTION
#### What does this PR do?
Add endpoint for deleting a specific car Ad
#### Description of Task to be completed?
Admin should be able to delete a specific car Ad
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Signup or signin to recieve an access token
       * Send a post request to the url `localhost/api/v1/car` with the required fields
      * Send a delete request to the url `localhost/api/v1/car/:carId`
      *  Set the header `content-type` to `application/json`
      * Set the header `authorization` to `Bearer  ** token you got upon signup**`
#### Any background context you want to provide?
No
#### What are the relevant pivotal tracker stories?
#166283068
#### Screenshots (if appropriate)

![delete car ad](https://user-images.githubusercontent.com/33099347/58725950-5bedda80-83d8-11e9-8fc5-bfff313ab8a6.png)