### PR TITLE
#166695583 Update user sign-in route to use database instead of data-structures

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -41,18 +41,20 @@ class UserController {
    * @param {object} res - response
    */
   static async loginUser(req, res) {
-    const { email, password } = req.body;
     try {
-      const user = userModel.find(usr => (usr.email === email)
-        && (passwordHash.verify(password, usr.password)));
-      if (user && user !== undefined) {
-        const { id, isAdmin } = user;
-        const token = await generateToken({ id, isAdmin });
-        return res.status(200).json({ data: [{ token, user }], message: 'Login successful' });
+      const { email, password } = req.body;
+      const user = await userModel.findByEmail(email);
+      if (user) {
+        if (passwordHash.verify(password, user.password)) {
+          const { id, isadmin } = user;
+          const token = await generateToken({ id, isadmin });
+          return res.status(200).json({ data: [{ token, user }], message: 'Login successful' });
+        }
+        return res.status(401).json({ error: true, message: 'Invalid email or password' });
       }
       return res.status(401).json({ error: true, message: 'Invalid email or password' });
     } catch (err) {
-      return res.status(500).json({ error: true, message: 'Internal server error' });
+      return res.status(500).json({ error: true, message: 'Internal Server error' });
     }
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Update endpoint for logging-in to use database
#### Description of Task to be completed?
Users should be able to log into their accounts
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Send a post request to the url `localhost/api/v1/auth/login`
#### Any background context you want to provide?
The previous version only uses a data structure to store records which isn't persistent
#### What are the relevant pivotal tracker stories?
#166695583
#### Screenshots
![Screen Shot 2019-05-28 at 9 28 25 PM](https://user-images.githubusercontent.com/33099347/59519457-c7977380-8ebf-11e9-9b0a-655c443a5c3d.png)
