### PR TITLE
#166695674 Update create car Ad route to use database instead of data-structures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ cache:
     - "node_modules"
 env: 
   - SECRET=SuperSecretTokenKeyXXX&*& DB_URL=postgres://tpysktxx:Q3JLGS8Jd8saRWFSP9OWjY7GjiSDtL-S@raja.db.elephantsql.com:5432/tpysktxx
+before_script: npm run pretest
 script: npm test
 after_success: npm run coveralls

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "pretest": "npm run migrate:reset && npm run migrate && npm run seed",
     "seed": "DEBUG=seed babel-node ./server/database/seeds",
     "start": "export NODE_ENV=production && babel-node ./server/app.js",
-    "test": "npm run pretest && mocha --require @babel/register ./server/test/**/*.js  --exit"
+    "test": "mocha --require @babel/register ./server/test/**/*.js  --exit"
   },
   "repository": {
     "type": "git",

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -1,5 +1,4 @@
 import passwordHash from 'password-hash';
-import shortId from 'shortid';
 import Auth from '../helpers/auth';
 import userModel from '../models/users';
 

--- a/server/controllers/carController.js
+++ b/server/controllers/carController.js
@@ -1,29 +1,20 @@
-import shortId from 'shortid';
 import carModel from '../models/cars';
-import Helper  from '../helpers/index'
+import Helper from '../helpers/index'
 class CarController {
-  /**
-           *
-           * @param {object} req - request
-           * @param {object} res - response
-           */
+
   static async createCarAd(req, res) {
-    /* istanbul ignore next */
-    const id = shortId.generate();
-    const status = 'available';
-    const createdOn = new Date();
     try {
       const { id: owner } = req.body.tokenPayload;
-      const { state, price, manufacturer, model, bodyType } = req.body;
-      const car = {
-        id, owner, createdOn, state, status, price, manufacturer, model, bodyType,
-      };
-      carModel.push(car);
-      return res.status(201).json({
-        status: 201,
-        data: [car],
-        message: 'Car Ad created successfully',
-      });
+      const { state, price, manufacturer, model, bodyType, mainImageUrl } = req.body;
+      const values = [owner, state, price, manufacturer, model, bodyType, mainImageUrl];
+      const car = await carModel.create(values);
+      if (car) {
+        return res.status(201).json({
+          status: 201,
+          data: [car],
+          message: 'Car Ad created successfully',
+        });
+      }
     } catch (err) {
       return res.status(500).json({ error: true, message: 'Internal server error' });
     }

--- a/server/middlewares/authValidator.js
+++ b/server/middlewares/authValidator.js
@@ -105,7 +105,7 @@ class AuthValidator {
    * @param {object} next - callback
    * @returns
    */
-  static isTokenValid(req, res, next) {
+  static async isTokenValid(req, res, next) {
     try {
       let authorization;
       if (req.headers.token) authorization = req.headers.token;
@@ -113,12 +113,12 @@ class AuthValidator {
       if (!authorization) {
         return res.status(401).json({ status: 401, error: 'You must log in to continue' });
       }
-      jwt.verify(authorization, SECRET, (err, decoded) => {
+      jwt.verify(authorization, process.env.SECRET, async (err, decoded) => {
         if (err) {
           return res.status(401).json({ status: 401, error: 'Invalid token, kindly log in to continue' });
         }
         const { id } = decoded;
-        const user = UserModel.find(usr => usr.id === id);
+        const user = await UserModel.findById(id);
         if (user) {
           req.body.tokenPayload = decoded;
           return next();
@@ -126,7 +126,7 @@ class AuthValidator {
         return res.status(401).json({ status: 401, error: 'User with the specified token does not exist' });
       });
     } catch (err) {
-      return res.status(401).json({ status: 401, error: 'Internal server error, please try again' });
+      return res.status(401).json({ status: 401, error: 'Kindly login to continue' });
     }
   }
 

--- a/server/middlewares/carValidator.js
+++ b/server/middlewares/carValidator.js
@@ -6,12 +6,17 @@ const { extractErrors } = Helpers;
 class CarValidator {
   static validateCar(req, res, next) {
     req.checkBody('state', 'Car state is required').notEmpty().trim().isAlpha()
-      .withMessage('Car state can only contain alphabets');
+      .withMessage('Car state can only contain alphabets')
+      .isIn(['New', 'Used'])
+      .withMessage('Car state must be either New or Used, notice the uppercase');
     req.checkBody('price', 'Car price is required').notEmpty().isCurrency({ allow_negatives: false, require_decimal: true })
       .withMessage('Car price must be a valid number in two decimal place, e.g 123000.00');
     req.checkBody('manufacturer', 'Car manufacturer is required').notEmpty().trim();
     req.checkBody('model', 'Car model is required').notEmpty().trim();
     req.checkBody('bodyType', 'Car body type is required').notEmpty();
+    req.checkBody('mainImageUrl', 'Car main image url is required').notEmpty().isString()
+      .withMessage('Car main image url must be a string');
+
     const errors = req.validationErrors();
     if (errors) {
       return res.status(400).json({ status: 400, errors: extractErrors(errors) });

--- a/server/models/cars.js
+++ b/server/models/cars.js
@@ -1,3 +1,23 @@
-const CarModel = [];
+import pool from '../config/connection';
 
-export default CarModel;
+class Car {
+  static async create(values) {
+    const client = await pool.connect();
+    let car;
+    const text = `INSERT INTO cars(owner,state, price, manufacturer, model, bodyType, mainImageUrl)
+      VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING *`;
+    try {
+      car = await client.query({ text, values });
+      if (car.rowCount) {
+        car = car.rows[0];
+        return car;
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      await client.release();
+    }
+  }
+}
+export default Car;

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -38,5 +38,24 @@ class User {
       client.release();
     }
   }
+
+  static async findById(id) {
+    const values = [id];
+    const client = await pool.connect();
+    let user;
+    const text = 'SELECT * FROM users WHERE id = $1';
+    try {
+      user = await client.query({ text, values });
+      if (user.rows && user.rowCount) {
+        user = user.rows[0];
+        return user;
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
 }
 export default User;


### PR DESCRIPTION
#### What does this PR do?
Update create car Ad endpoint to use a database instead of data-structures
#### Description of Task to be completed?
User should be able to successfully create a car Ad
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Signup or signin to recieve an access token
       * Send a post request to the url `localhost/api/v1/car` with the required fields
      *  Set the header `content-type` to `application/json`
      * Set the header `authorization` to `Bearer  ** token you got upon signup**`
#### Any background context you want to provide?
The previous version only uses a data structure to store records which isn't persistent
#### What are the relevant pivotal tracker stories?
#166695674
#### Screenshots
![Screen Shot 2019-05-28 at 9 58 56 PM](https://user-images.githubusercontent.com/33099347/59528240-a04ba100-8ed5-11e9-81a5-246fc39efab0.png)
 