### PR TITLE
#166696181 update get all cars route to cater for a single purpose and use database instead of data-structures

### DIFF
--- a/server/controllers/carController.js
+++ b/server/controllers/carController.js
@@ -63,36 +63,14 @@ class CarController {
   }
 
   static async getAllCars(req, res) {
-    const { status, minPrice, maxPrice, state, manufacturer, bodyType } = req.query;
-    let cars;
-    let error;
     try {
-      if (status && minPrice && maxPrice) {
-        cars = carModel.filter(car => (car.status === status)
-          && (Number(car.price) >= Number(minPrice)) && (Number(car.price) <= Number(maxPrice)));
-        if (!cars.length) error = `No car exist with status: ${status} and price between ${minPrice} and ${maxPrice}`;
-      } else if (status && state) {
-        cars = carModel.filter(car => car.status === status && car.state === state);
-        if (!cars.length) error = `No car exist with state: ${state}`;
-      } else if (status && manufacturer) {
-        cars = carModel.filter(car => car.status === status && car.manufacturer === manufacturer);
-        if (!cars.length) error = `No car exist with manufacturer: ${manufacturer}`;
-      } else if (status && bodyType) {
-        cars = carModel.filter(car => car.status === status && car.bodyType === bodyType);
-        if (!cars.length) error = `No car exist with body type: ${bodyType}`;
-      } else if (status) {
-        cars = carModel.filter(car => car.status === status);
-        if (!cars.length) error = `No car exist with status: ${status}`;
-      } else {
-        cars = carModel;
-        if (!cars.length) error = 'No car found';
-      }
-      if (cars.length) {
+      const cars = await carModel.getAll();
+      if (cars) {
         return res.status(200).json({ status: 200, data: [cars] });
       }
       return res.status(404).json({
         status: 404,
-        error,
+        error: 'No car exist',
       });
     } catch (err) {
       return res.status(500).json({ status: 500, error: 'Internal server error' });

--- a/server/middlewares/authValidator.js
+++ b/server/middlewares/authValidator.js
@@ -140,22 +140,22 @@ class AuthValidator {
   * @returns
   */
 
-  static isAdmin(req, res, next) {
-    try {
-      const authorization = req.headers.authorization.split(' ')[1] || req.headers.token;
+ static isAdmin(req, res, next) {
+  try {
+    const authorization = req.headers.authorization.split(' ')[1] || req.headers.token;
 
-      if (!authorization) {
-        return res.status(401).json({ status: 401, message: 'Invalid token, kindly log in to continue' });
-      }
-      const verifiedToken = verifyToken(authorization);
-      if (!verifiedToken.isAdmin) {
-        return res.status(401).json({ status: 401, message: 'Only an Admin can perform this task' });
-      }
-    } catch (err) {
-      return res.status(401).json({ status: 500, message: 'Internal server error, please try again' });
+    if (!authorization) {
+      return res.status(401).json({ status: 401, message: 'Invalid token, kindly log in to continue' });
     }
-    return next();
+    const verifiedToken = verifyToken(authorization);
+    if (!verifiedToken.isadmin) {
+      return res.status(401).json({ status: 401, message: 'Only an Admin can perform this task' });
+    }
+  } catch (err) {
+    return res.status(401).json({ status: 500, message: 'Internal server error, please try again' });
   }
+  return next();
+}
 }
 
 export default AuthValidator;

--- a/server/models/cars.js
+++ b/server/models/cars.js
@@ -19,5 +19,22 @@ class Car {
       await client.release();
     }
   }
+
+  static async getAll() {
+    const client = await pool.connect();
+    let cars;
+    const text = 'SELECT * FROM cars';
+    try {
+      cars = await client.query({ text });
+      if (cars.rows && cars.rowCount) {
+        return cars.rows;
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
 }
 export default Car;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -29,14 +29,6 @@ router.get('/', (req, res) => {
 router.use('/api/docs', swagger.serve);
 router.get('/api/docs', swagger.setup(docs));
 
-// 404 Routes
-router.get('*', (req, res, next) => {
-  res.status(404).json({
-    message: 'Invalid Endpoint',
-  });
-  return next();
-});
-
 // Auth routes
 const authBaseUrl = '/api/v1/auth';
 router.post(`${authBaseUrl}/signup`, validateSignUp, userExists, createAccount);
@@ -45,10 +37,10 @@ router.post(`${authBaseUrl}/login`, validateLogin, loginUser);
 // Car routes
 const carBaseUrl = '/api/v1/car';
 router.post(`${carBaseUrl}`, isTokenValid, validateCar, createCarAd);
+router.get(`${carBaseUrl}`, isTokenValid, isAdmin, getAllCars);
 router.patch(`${carBaseUrl}/:carId/status`, isTokenValid, isCarExist, isCarOwner, validateStatus, updateCarAdStatus);
 router.patch(`${carBaseUrl}/:carId/price`, isTokenValid, isCarExist, isCarOwner, validatePrice, updateCarAdPrice);
 router.get(`${carBaseUrl}/:carId`, isTokenValid, getACar);
-router.get(`${carBaseUrl}`, isTokenValid, validateParams, getAllCars);
 router.delete(`${carBaseUrl}/:carId`, isTokenValid, isAdmin, deleteCarAd);
 
 // Order routes


### PR DESCRIPTION
#### What does this PR do?
Update get all car Ad endpoint to use a database instead of data-structures
#### Description of Task to be completed?
User (Admin) should be able to successfully get all car Ads
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Sign in as an admin to receive an access token
       * Send a`GET` request to the URL `localhost/api/v1/car` with the required fields
      *  Set the header `content-type` to `application/json`
      * Set the header `authorization` to `Bearer  ** token you got upon signup**`
#### Any background context you want to provide?
The previous version only uses a data structure to store records which isn't persistent
#### What are the relevant pivotal tracker stories?
#166696181
#### Screenshots
![get all car sold or not](https://user-images.githubusercontent.com/33099347/59535778-b6fbf300-8ee9-11e9-9fce-1edf91c8b89b.png)
