### PR TITLE
#166695749 Update user can update car Ad status to use database instead of data-structures

### DIFF
--- a/server/controllers/carController.js
+++ b/server/controllers/carController.js
@@ -23,11 +23,16 @@ class CarController {
   static async updateCarAdStatus(req, res) {
     const { carId } = req.params;
     const { status } = req.body;
+    const data = { name: 'status', value: status };
     try {
-      let car = carModel.find(car => car.id === carId);
-      car = { status, ...car };
-      Helper.updateModel(req, res, carModel, car, carId, 'Car')
-      return res.status(500).json({ status: 500, error: 'Oops, something happend, try again' });
+      const car = await carModel.update(carId, data);
+      if (car) {
+        return res.status(200).json({
+          status: 200,
+          data: [car],
+          message: 'Car Ad updated successfully',
+        });
+      }
     } catch (err) {
       return res.status(500).json({ status: 500, error: 'Internal Server error' });
     }

--- a/server/middlewares/carValidator.js
+++ b/server/middlewares/carValidator.js
@@ -24,10 +24,10 @@ class CarValidator {
     return next();
   }
 
-  static isCarExist(req, res, next) {
+  static async isCarExist(req, res, next) {
     const carId = req.params.carId || req.body.carId;
     try {
-      const car = carModel.find(cr => cr.id === carId);
+      const car = await carModel.getById(carId);
       if (!car) {
         return res.status(404).json({ status: 404, error: `Car Ad with id: ${carId} does not exist` });
       }
@@ -37,11 +37,11 @@ class CarValidator {
     }
   }
 
-  static isCarOwner(req, res, next) {
+  static async isCarOwner(req, res, next) {
     const { id: ownerId } = req.body.tokenPayload;
     const { carId } = req.params;
     try {
-      const car = carModel.find(cr => cr.id === carId);
+      const car = await carModel.getById(carId);
       if (car) {
         if (car.owner === ownerId) {
           return next();
@@ -55,8 +55,8 @@ class CarValidator {
   }
 
   static validateStatus(req, res, next) {
-    req.checkBody('status', 'Car status is required').notEmpty().trim().isIn(['sold', 'available'])
-      .withMessage('Car status can only be sold or available')
+    req.checkBody('status', 'Car status is required').notEmpty().trim().isIn(['Sold', 'Available'])
+      .withMessage('Car status can only be Sold or Available, notice the uppercase')
       .isString()
       .withMessage('Car status must be a string');
 

--- a/server/models/cars.js
+++ b/server/models/cars.js
@@ -36,5 +36,42 @@ class Car {
       client.release();
     }
   }
+
+  static async getById(id) {
+    const values = [id];
+    const client = await pool.connect();
+    let car;
+    const text = 'SELECT * FROM cars WHERE id = $1 LIMIT 1';
+    try {
+      car = await client.query({ text, values });
+      if (car.rows && car.rowCount) {
+        car = car.rows[0];
+        return car;
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  static async update(id, data) {
+    const values = [data.value, id];
+    const client = await pool.connect();
+    let car;
+    const text = `UPDATE cars SET ${data.name} = $1 WHERE id = $2 RETURNING *`;
+    try {
+      car = await client.query({ text, values });
+      if (car.rowCount) {
+        return car.rows[0];
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
 }
 export default Car;


### PR DESCRIPTION
#### What does this PR do?
Update 'Update car status' endpoint to use a database instead of data-structures
#### Description of Task to be completed?
User (Seller) should be able to successfully update his car Ads' status
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Sign up or Sign In to receive an access token
       * Send a`PATCH` request to the URL `localhost/api/v1/car/:carId/status` with the required fields
      *  Set the header `content-type` to `application/json`
      * Set the header `authorization` to `Bearer  ** token you got upon signup**`
#### Any background context you want to provide?
The previous version only uses a data structure to store records which isn't persistent
#### What are the relevant pivotal tracker stories?
#166695749
#### Screenshots

![update car status](https://user-images.githubusercontent.com/33099347/59536801-abf69200-8eec-11e9-81b9-ab4fefaa84ca.png)
