### PR TITLE
#166695980 User can filter car ads by status

### DIFF
--- a/server/controllers/carController.js
+++ b/server/controllers/carController.js
@@ -106,6 +106,23 @@ class CarController {
       return res.status(500).json({ status: 500, error: 'Internal Server error' });
     }
   }
+
+  static async getCarsByStatus(req, res) {
+    const { status } = req.query;
+    try {
+      const cars = await carModel.getByStatus(status);
+      if (cars) {
+        return res.status(200).json({ status: 200, data: [cars] });
+      }
+      return res.status(404).json({
+        status: 404,
+        error: `No car exist with status: ${status}`,
+      });
+    } catch (err) {
+      return res.status(500).json({ status: 500, error: 'Internal server error' });
+    }
+  }
+
 }
 
 export default CarController;

--- a/server/middlewares/carValidator.js
+++ b/server/middlewares/carValidator.js
@@ -80,25 +80,37 @@ class CarValidator {
 
   static validateParams(req, res, next) {
     const keys = Object.keys(req.query);
-    const allowedStatus = ['available', 'sold'];
+    const allowedStatuses = ['Available', 'Sold'];
+    const allowedStates = ['New', 'Used'];
+    let error;
     if (keys.length === 0) {
       return authValidator.isAdmin(req, res, next);
     }
     keys.forEach((key) => {
-      switch (req.params[key]) {
+      switch (key) {
         case 'status':
-          if (!allowedStatus.includes(req.params[keys])) return res.status(400).json({ status: 400, errors: 'status must either be sold or availble' });
+          if (!allowedStatuses.includes(req.query[key])) error = 'status must either be Sold or Availble, notice the uppercase';
           break;
         case 'minPrice':
-          if (!req.params.maxPrice) return res.status({ status: 400, error: 'There must also be a maxPrice' });
+          if (!req.query.maxPrice) error = 'There must also be a maxPrice';
           break;
         case 'maxPrice':
-          if (!req.params.minPrice) return res.status({ status: 400, error: 'There must also be a minPrice' });
+          if (!req.query.minPrice) error = 'There must also be a minPrice';
+          break;
+        case 'state':
+          if (!allowedStates.includes(req.query[key])) error = 'state must either be Used or New, notice the uppercase';
+          break;
+        case 'manufacturer':
+          break;
+        case 'bodyType':
           break;
         default:
-          return res.status({ status: 400, error: 'Invalid filter provided' });
+          error = 'Invalid filter provided';
       }
     });
+    if (error) {
+      return res.status(400).json({ status: 400, error });
+    }
     next();
   }
 }

--- a/server/models/cars.js
+++ b/server/models/cars.js
@@ -73,5 +73,24 @@ class Car {
       client.release();
     }
   }
+
+  static async getByStatus(status) {
+    const values = [status];
+    const client = await pool.connect();
+    let cars;
+    const text = 'SELECT * FROM cars WHERE status = $1';
+    try {
+      cars = await client.query({ text, values });
+      if (cars.rows && cars.rowCount) {
+        cars = cars.rows;
+        return cars;
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
 }
 export default Car;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -15,7 +15,7 @@ const router = express.Router();
 const { createAccount, loginUser } = AuthController;
 const { validateSignUp, userExists, validateLogin, isTokenValid, isAdmin } = AuthValidator;
 const { createCarAd, updateCarAdStatus, updateCarAdPrice,
-  getACar, getAllCars, deleteCarAd } = CarController;
+  getACar, getAllCars, deleteCarAd, getCarsByStatus } = CarController;
 const { validateCar, isCarExist, isCarOwner, validateStatus,
   validatePrice, validateParams } = CarValidator;
 const { validateOrder, isOrderOwner, validateAmount } = OrderValidator;
@@ -40,6 +40,7 @@ router.post(`${carBaseUrl}`, isTokenValid, validateCar, createCarAd);
 router.get(`${carBaseUrl}`, isTokenValid, isAdmin, getAllCars);
 router.patch(`${carBaseUrl}/:carId/status`, isTokenValid, isCarExist, isCarOwner, validateStatus, updateCarAdStatus);
 router.patch(`${carBaseUrl}/:carId/price`, isTokenValid, isCarExist, isCarOwner, validatePrice, updateCarAdPrice);
+router.get(`${carBaseUrl}/getByStatus`, isTokenValid, validateParams, getCarsByStatus);
 router.get(`${carBaseUrl}/:carId`, isTokenValid, getACar);
 router.delete(`${carBaseUrl}/:carId`, isTokenValid, isAdmin, deleteCarAd);
 


### PR DESCRIPTION
#### What does this PR do?
Implement 'Filter car Ads by status' endpoint so that it uses a database instead of data-structures
#### Description of Task to be completed?
User should be able to successfully filter all car Ads by status
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Signup/Signin to receive an access token
       * Send a`GET` request to the URL `localhost/api/v1/car/getByStatus?status=Available` with the required fields
      *  Set the header `content-type` to `application/json`
      * Set the header `authorization` to `Bearer  ** token you got upon signup**`
#### Any background context you want to provide?
The previous version only uses a data structure to store records which isn't persistent
#### What are the relevant pivotal tracker stories?
#166695980
#### Screenshots
![all available cars](https://user-images.githubusercontent.com/33099347/59538930-45c13d80-8ef3-11e9-8683-fa9e9be6c772.png)

