### PR TITLE
166696026 Implement user can filter car Ads by state route

### DIFF
--- a/server/controllers/carController.js
+++ b/server/controllers/carController.js
@@ -123,6 +123,23 @@ class CarController {
     }
   }
 
+  static async getCarsByState(req, res) {
+    const { status, state } = req.query;
+    const filter = { name: 'state', value: state };
+    try {
+      const cars = await carModel.getByFilter(status, filter);
+      if (cars) {
+        return res.status(200).json({ status: 200, data: [cars] });
+      }
+      return res.status(404).json({
+        status: 404,
+        error: `No car exist with state: ${state}`,
+      });
+    } catch (err) {
+      return res.status(500).json({ status: 500, error: 'Internal server error' });
+    }
+  }
+
 }
 
 export default CarController;

--- a/server/models/cars.js
+++ b/server/models/cars.js
@@ -92,5 +92,24 @@ class Car {
       client.release();
     }
   }
+
+  static async getByFilter(status, filter) {
+    const values = [status, filter.value];
+    const client = await pool.connect();
+    let car;
+    const text = `SELECT * FROM cars WHERE status = $1 AND ${filter.name} = $2`;
+    try {
+      car = await client.query({ text, values });
+      if (car.rows && car.rowCount) {
+        car = car.rows;
+        return car;
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
 }
 export default Car;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -15,7 +15,7 @@ const router = express.Router();
 const { createAccount, loginUser } = AuthController;
 const { validateSignUp, userExists, validateLogin, isTokenValid, isAdmin } = AuthValidator;
 const { createCarAd, updateCarAdStatus, updateCarAdPrice,
-  getACar, getAllCars, deleteCarAd, getCarsByStatus } = CarController;
+  getACar, getAllCars, deleteCarAd, getCarsByStatus, getCarsByState } = CarController;
 const { validateCar, isCarExist, isCarOwner, validateStatus,
   validatePrice, validateParams } = CarValidator;
 const { validateOrder, isOrderOwner, validateAmount } = OrderValidator;
@@ -41,6 +41,7 @@ router.get(`${carBaseUrl}`, isTokenValid, isAdmin, getAllCars);
 router.patch(`${carBaseUrl}/:carId/status`, isTokenValid, isCarExist, isCarOwner, validateStatus, updateCarAdStatus);
 router.patch(`${carBaseUrl}/:carId/price`, isTokenValid, isCarExist, isCarOwner, validatePrice, updateCarAdPrice);
 router.get(`${carBaseUrl}/getByStatus`, isTokenValid, validateParams, getCarsByStatus);
+router.get(`${carBaseUrl}/getByState`, isTokenValid, validateParams, getCarsByState);
 router.get(`${carBaseUrl}/:carId`, isTokenValid, getACar);
 router.delete(`${carBaseUrl}/:carId`, isTokenValid, isAdmin, deleteCarAd);
 


### PR DESCRIPTION
#### What does this PR do?
Implement 'User can filter car Ad by state' endpoint so that it  uses a database instead of data-structures
#### Description of Task to be completed?
User should be able to successfully filter car Ads by state
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Sign in as an admin to receive an access token
       * Send a`GET` request to the URL `localhost/api/v1/car/getByState?status=Availabe&state=Used` with the required fields
      *  Set the header `content-type` to `application/json`
      * Set the header `authorization` to `Bearer  ** token you got upon signup**`
#### Any background context you want to provide?
The previous version only uses a data structure to store records which isn't persistent
#### What are the relevant pivotal tracker stories?
#166696026
#### Screenshots
![get cars by state](https://user-images.githubusercontent.com/33099347/59540888-04329180-8ef7-11e9-8daf-9a3a229284ad.png)
