### PR TITLE
#166696070 Implement route for filtering car Ads by manufacturer

### DIFF
--- a/server/controllers/carController.js
+++ b/server/controllers/carController.js
@@ -140,6 +140,23 @@ class CarController {
     }
   }
 
+  static async getCarsByManufacturer(req, res) {
+    const { status, manufacturer } = req.query;
+    const filter = { name: 'manufacturer', value: manufacturer };
+    try {
+      const cars = await carModel.getByFilter(status, filter);
+      if (cars) {
+        return res.status(200).json({ status: 200, data: [cars] });
+      }
+      return res.status(404).json({
+        status: 404,
+        error: `No car exist with manufacturer: ${manufacturer}`,
+      });
+    } catch (err) {
+      return res.status(500).json({ status: 500, error: 'Internal server error' });
+    }
+  }
+
 }
 
 export default CarController;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -15,7 +15,7 @@ const router = express.Router();
 const { createAccount, loginUser } = AuthController;
 const { validateSignUp, userExists, validateLogin, isTokenValid, isAdmin } = AuthValidator;
 const { createCarAd, updateCarAdStatus, updateCarAdPrice,
-  getACar, getAllCars, deleteCarAd, getCarsByStatus, getCarsByState } = CarController;
+  getACar, getAllCars, deleteCarAd, getCarsByStatus, getCarsByState, getCarsByManufacturer } = CarController;
 const { validateCar, isCarExist, isCarOwner, validateStatus,
   validatePrice, validateParams } = CarValidator;
 const { validateOrder, isOrderOwner, validateAmount } = OrderValidator;
@@ -42,6 +42,7 @@ router.patch(`${carBaseUrl}/:carId/status`, isTokenValid, isCarExist, isCarOwner
 router.patch(`${carBaseUrl}/:carId/price`, isTokenValid, isCarExist, isCarOwner, validatePrice, updateCarAdPrice);
 router.get(`${carBaseUrl}/getByStatus`, isTokenValid, validateParams, getCarsByStatus);
 router.get(`${carBaseUrl}/getByState`, isTokenValid, validateParams, getCarsByState);
+router.get(`${carBaseUrl}/getByManufacturer`, isTokenValid, validateParams, getCarsByManufacturer);
 router.get(`${carBaseUrl}/:carId`, isTokenValid, getACar);
 router.delete(`${carBaseUrl}/:carId`, isTokenValid, isAdmin, deleteCarAd);
 


### PR DESCRIPTION
#### What does this PR do?
Implement 'Filter car Ads by manufacturer' endpoint so that it uses a database instead of data-structures
#### Description of Task to be completed?
User should be able to successfully filter car Ads by manufacturer
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Sign in as an admin to receive an access token
       * Send a`GET` request to the URL `localhost/api/v1/car/getByManufacturer?status=Available&manufacturer=Toyota` with the required fields
      *  Set the header `content-type` to `application/json`
      * Set the header `authorization` to `Bearer  ** token you got upon signup**`
#### Any background context you want to provide?
The previous version only uses a data structure to store records which isn't persistent
#### What are the relevant pivotal tracker stories?
#166696070
#### Screenshots
![get by manufacturers](https://user-images.githubusercontent.com/33099347/59549141-3244bf80-8f51-11e9-9558-454940dec289.png)