### PR TITLE
#166696125 Implement route for filtering car Ads by body type

### DIFF
--- a/server/controllers/carController.js
+++ b/server/controllers/carController.js
@@ -1,5 +1,4 @@
 import carModel from '../models/cars';
-import Helper from '../helpers/index'
 class CarController {
 
   static async createCarAd(req, res) {
@@ -116,7 +115,7 @@ class CarController {
       }
       return res.status(404).json({
         status: 404,
-        error: `No car exist with status: ${status}`,
+        error: `No car exist with status: ${status}, status is case sensitive`,
       });
     } catch (err) {
       return res.status(500).json({ status: 500, error: 'Internal server error' });
@@ -133,7 +132,7 @@ class CarController {
       }
       return res.status(404).json({
         status: 404,
-        error: `No car exist with state: ${state}`,
+        error: `No car exist with state: ${state}, state is case sensitive`,
       });
     } catch (err) {
       return res.status(500).json({ status: 500, error: 'Internal server error' });
@@ -150,7 +149,7 @@ class CarController {
       }
       return res.status(404).json({
         status: 404,
-        error: `No car exist with manufacturer: ${manufacturer}`,
+        error: `No car exist with manufacturer: ${manufacturer}, manufacturer is case sensitive`,
       });
     } catch (err) {
       return res.status(500).json({ status: 500, error: 'Internal server error' });
@@ -170,6 +169,23 @@ class CarController {
       });
     } catch (err) {
       console.log(err)
+      return res.status(500).json({ status: 500, error: 'Internal server error' });
+    }
+  }
+
+  static async getCarsByBodyType(req, res) {
+    const { status, bodyType } = req.query;
+    const filter = { name: 'bodyType', value: bodyType };
+    try {
+      const cars = await carModel.getByFilter(status, filter);
+      if (cars) {
+        return res.status(200).json({ status: 200, data: [cars] });
+      }
+      return res.status(404).json({
+        status: 404,
+        error: `No car exist with body type: ${bodyType}, body type is case sensitive`,
+      });
+    } catch (err) {
       return res.status(500).json({ status: 500, error: 'Internal server error' });
     }
   }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -15,7 +15,8 @@ const router = express.Router();
 const { createAccount, loginUser } = AuthController;
 const { validateSignUp, userExists, validateLogin, isTokenValid, isAdmin } = AuthValidator;
 const { createCarAd, updateCarAdStatus, updateCarAdPrice,
-  getACar, getAllCars, deleteCarAd, getCarsByStatus, getCarsByState, getCarsByManufacturer, getCarsByPriceRange } = CarController;
+  getACar, getAllCars, deleteCarAd, getCarsByStatus, getCarsByState, getCarsByManufacturer,
+  getCarsByPriceRange, getCarsByBodyType } = CarController;
 const { validateCar, isCarExist, isCarOwner, validateStatus,
   validatePrice, validateParams } = CarValidator;
 const { validateOrder, isOrderOwner, validateAmount } = OrderValidator;
@@ -44,6 +45,7 @@ router.get(`${carBaseUrl}/getByStatus`, isTokenValid, validateParams, getCarsByS
 router.get(`${carBaseUrl}/getByState`, isTokenValid, validateParams, getCarsByState);
 router.get(`${carBaseUrl}/getByManufacturer`, isTokenValid, validateParams, getCarsByManufacturer);
 router.get(`${carBaseUrl}/getByPrice`, isTokenValid, validateParams, getCarsByPriceRange);
+router.get(`${carBaseUrl}/getByBodyType`, isTokenValid, validateParams, getCarsByBodyType);
 router.get(`${carBaseUrl}/:carId`, isTokenValid, getACar);
 router.delete(`${carBaseUrl}/:carId`, isTokenValid, isAdmin, deleteCarAd);
 


### PR DESCRIPTION
#### What does this PR do?
Implement 'Filter car Ads by body type' endpoint so that it uses a database instead of data-structures
#### Description of Task to be completed?
User should be able to successfully filter car Ads by body type
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Sign in as an admin to receive an access token
       * Send a `GET` request to the URL `localhost/api/v1/car/getByBodyType?status=Available&bodyType=truck` with the required fields
      *  Set the header `content-type` to `application/json`
      * Set the header `authorization` to `Bearer  ** token you got upon signup**`
#### Any background context you want to provide?
The previous version only uses a data structure to store records which isn't persistent
#### What are the relevant pivotal tracker stories?
#166696125
#### Screenshots
![get car with a specific body type](https://user-images.githubusercontent.com/33099347/59549814-df700580-8f5a-11e9-8502-e1f2d122e7f1.png)
