### PR TITLE
#166696217 Update 'Admin delete car route' to use a database instead of data-structure

### DIFF
--- a/server/controllers/carController.js
+++ b/server/controllers/carController.js
@@ -90,15 +90,13 @@ class CarController {
   static async deleteCarAd(req, res) {
     const { carId } = req.params;
     try {
-      for (let i = 0; i < carModel.length; i += 1) {
-        if (carModel[i].id === carId) {
-          carModel.splice(i, 1);
-          return res.status(200).json({
-            status: 204,
-            data: [],
-            message: 'Car Ad deleted successfully',
-          });
-        }
+      const car = await carModel.delete(carId);
+      if (car) {
+        return res.status(200).json({
+          status: 204,
+          data: [],
+          message: 'Car Ad deleted successfully',
+        });
       }
       return res.status(404).json({ status: 404, message: `Car with id: ${carId} not found` });
     } catch (err) {

--- a/server/models/cars.js
+++ b/server/models/cars.js
@@ -130,5 +130,24 @@ class Car {
       client.release();
     }
   }
+
+  static async delete(id) {
+    const values = [id];
+    const client = await pool.connect();
+    let car;
+    const text = 'DELETE FROM cars WHERE id = $1 RETURNING id';
+    try {
+      car = await client.query({ text, values });
+      if (car.rowCount) {
+        return true;
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
 }
 export default Car;


### PR DESCRIPTION
#### What does this PR do?
Update the 'Delete car Ad' endpoint to use a database instead of data-structures
#### Description of Task to be completed?
User (Admin) should be able to successfully delete a car Ads
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Sign in as an admin to receive an access token
       * Send a `DELETE` request to the URL `localhost/api/v1/car/:carId` with the required fields
      *  Set the header `content-type` to `application/json`
      * Set the header `authorization` to `Bearer  ** token you got upon signup**`
#### Any background context you want to provide?
The previous version only uses a data structure to store records which isn't persistent
#### What are the relevant pivotal tracker stories?
#166696217
#### Screenshots
![delete car ad](https://user-images.githubusercontent.com/33099347/59552962-dd6f6c00-8f85-11e9-8cd8-1048eecacf1b.png)
