### PR TITLE
#166695722 Update 'user can update order amount' endpoint to use a database instead of data-structure

### DIFF
--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -20,17 +20,20 @@ class OrderController {
     }
   }
 
-  static async updateOrderPrice(req, res) {
+  static async updateOrderAmount(req, res) {
+    const { orderId } = req.params;
+    const { amount } = req.body;
+    const data = { name: 'amount', value: amount };
     try {
-      const { orderId } = req.params;
-      const { amount } = req.body;
-      let order = orderModel.find(order => order.id === orderId);
-      if (!order) {
-        return res.status(400).json({ status: 400, message: `Purchase order with id: ${orderId} does not exist` });
+      const order = await orderModel.update(orderId, data);
+      if (order) {
+        return res.status(200).json({
+          status: 200,
+          data: [order],
+          message: 'Car order updated successfully',
+        });
       }
-      order = { ...order, amount };
-      Helper.updateModel(req, res, orderModel, order, orderId, 'Order')
-      return res.status(500).json({ status: 500, error: 'Oops, something happend, try again' });
+      return res.status(500).json({ status: 404, error: `Car order with id: ${orderId} does not exist` });
     } catch (err) {
       return res.status(500).json({ status: 500, error: 'Internal Server error' });
     }

--- a/server/middlewares/orderValidator.js
+++ b/server/middlewares/orderValidator.js
@@ -16,12 +16,11 @@ class OrderValidator {
     }
     return next();
   }
-
-  static isOrderOwner(req, res, next) {
+  static async isOrderOwner(req, res, next) {
     const { id: buyerId } = req.body.tokenPayload;
     const { orderId } = req.params;
     try {
-      const order = OrderModel.find(odr => odr.id === orderId);
+      const order = await OrderModel.getById(orderId);
       if (order) {
         if (order.buyer === buyerId) {
           return next();
@@ -35,7 +34,7 @@ class OrderValidator {
   }
 
   static validateAmount(req, res, next) {
-    req.checkBody('amount', 'Order amount is required').notEmpty().trim().isCurrency({ allow_negatives: false, require_decimal: true })
+    req.checkBody('amount', 'Order amount is required').notEmpty().isCurrency({ allow_negatives: false, require_decimal: true })
       .withMessage('Order amount must be a valid number in two decimal place, e.g 123000.00');
 
     const errors = req.validationErrors();

--- a/server/models/order.js
+++ b/server/models/order.js
@@ -19,5 +19,42 @@ class Order {
       await client.release();
     }
   }
+
+  static async getById(id) {
+    const values = [id];
+    const client = await pool.connect();
+    let order;
+    const text = 'SELECT * FROM orders WHERE id = $1 LIMIT 1';
+    try {
+      order = await client.query({ text, values });
+      if (order.rows && order.rowCount) {
+        order = order.rows[0];
+        return order;
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  static async update(id, data) {
+    const values = [data.value, id];
+    const client = await pool.connect();
+    let order;
+    const text = `UPDATE orders SET ${data.name} = $1 WHERE id = $2 RETURNING *`;
+    try {
+      order = await client.query({ text, values });
+      if (order.rowCount) {
+        return order.rows[0];
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
 }
 export default Order;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -20,7 +20,7 @@ const { createCarAd, updateCarAdStatus, updateCarAdPrice,
 const { validateCar, isCarExist, isCarOwner, validateStatus,
   validatePrice, validateParams } = CarValidator;
 const { validateOrder, isOrderOwner, validateAmount } = OrderValidator;
-const { createOrder, updateOrderPrice } = OrderController;
+const { createOrder, updateOrderAmount } = OrderController;
 
 router.get('/', (req, res) => {
   res.send(helpers.apiLandingPage());
@@ -52,6 +52,6 @@ router.delete(`${carBaseUrl}/:carId`, isTokenValid, isAdmin, deleteCarAd);
 // Order routes
 const orderBaseUrl = '/api/v1/order';
 router.post(`${orderBaseUrl}`, isTokenValid, validateOrder, isCarExist, createOrder);
-router.patch(`${orderBaseUrl}/:orderId/price`, isTokenValid, isOrderOwner, validateAmount, updateOrderPrice);
+router.patch(`${orderBaseUrl}/:orderId/amount`, isTokenValid, isOrderOwner, validateAmount, updateOrderAmount);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Update 'user (Buyer) can update order amount' endpoint to use a database instead of data-structures
#### Description of Task to be completed?
User (Buyer) should be able to successfully update order amount
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Signin/Signup to receive an access token
       * Send a `PATCH` request to the URL `localhost/api/v1/order/:orderId` with the required fields
      *  Set the header `content-type` to `application/json`
      * Set the header `authorization` to `Bearer  ** token you got upon signup**`
#### Any background context you want to provide?
The previous version only uses a data structure to store records which isn't persistent
#### What are the relevant pivotal tracker stories?
#166695722
#### Screenshots
![update order amount](https://user-images.githubusercontent.com/33099347/59553586-b2d5e100-8f8e-11e9-8f42-68e413326f8e.png)
