### PR TITLE
#166993545 Implement user can view his/her Ads history endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ My Heroku Link can be found [ here ](https://andela-auto-mart.herokuapp.com)
 9. User can view all unsold cars.
 10. User can view all unsold cars within a price range.
 11. Admin can delete a posted AD record.
-12. Admin can view all posted ads whether sold or unsold.
+12. Admin can view all posted ADs whether sold or unsold.
 
 ### Additional Features
 1. User can reset password.
@@ -39,6 +39,7 @@ My Heroku Link can be found [ here ](https://andela-auto-mart.herokuapp.com)
 4. User can view all used unsold cars.
 5. User can view all new unsold cars.
 6. User can view all unsold cars of a specific make (manufacturer).
+7. User can view his Ads history.
 
 ### Prerequisites
 - [Node.js](nodejs.org) must be installed 

--- a/server/controllers/carController.js
+++ b/server/controllers/carController.js
@@ -186,6 +186,22 @@ class CarController {
       return res.status(500).json({ status: 500, error: 'Internal server error' });
     }
   }
+
+  static async getUserCars(req, res) {
+    const { id: userId } = req.body.tokenPayload;
+    try {
+      const cars = await carModel.getByOwner(userId);
+      if (cars) {
+        return res.status(200).json({ status: 200, data: cars });
+      }
+      return res.status(404).json({
+        status: 404,
+        error: 'No cars found'
+      })
+    } catch (err) {
+      return res.status(500).json({ status: 500, error: 'Internal server error' })
+    }
+  }
 }
 
 export default CarController;

--- a/server/models/cars.js
+++ b/server/models/cars.js
@@ -131,6 +131,25 @@ class Car {
     }
   }
 
+  static async getByOwner(owner) {
+    const values = [owner];
+    const client = await pool.connect();
+    let car;
+    const text = 'SELECT * FROM cars WHERE owner = $1';
+    try {
+      car = await client.query({ text, values });
+      if (car.rows && car.rowCount) {
+        car = car.rows;
+        return car;
+      }
+      return false;
+    } catch (err) {
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
   static async delete(id) {
     const values = [id];
     const client = await pool.connect();

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -18,7 +18,7 @@ const { createAccount, loginUser, resetPassword, resetPasswordForm, passwordRese
 const { validateSignUp, userExists, validateLogin, isTokenValid, isAdmin } = AuthValidator;
 const { createCarAd, updateCarAdStatus, updateCarAdPrice,
   getACar, getAllCars, deleteCarAd, getCarsByStatus, getCarsByState, getCarsByManufacturer,
-  getCarsByPriceRange, getCarsByBodyType } = CarController;
+  getCarsByPriceRange, getCarsByBodyType, getUserCars } = CarController;
 const { validateCar, isCarExist, isCarOwner, validateStatus,
   validatePrice, validateParams } = CarValidator;
 const { validateOrder, isOrderOwner, validateAmount } = OrderValidator;
@@ -50,6 +50,7 @@ router.post(`${passwordResetBaseUrl}/reset`, resetPassword);
 const carBaseUrl = '/api/v1/car';
 router.post(`${carBaseUrl}`, isTokenValid, validateCar, createCarAd);
 router.get(`${carBaseUrl}`, isTokenValid, isAdmin, getAllCars);
+router.get(`${carBaseUrl}/history`, isTokenValid, getUserCars);
 router.patch(`${carBaseUrl}/:carId/status`, isTokenValid, isCarExist, isCarOwner, validateStatus, updateCarAdStatus);
 router.patch(`${carBaseUrl}/:carId/price`, isTokenValid, isCarExist, isCarOwner, validatePrice, updateCarAdPrice);
 router.get(`${carBaseUrl}/getByStatus`, isTokenValid, validateParams, getCarsByStatus);
@@ -68,5 +69,6 @@ router.patch(`${orderBaseUrl}/:orderId/amount`, isTokenValid, isOrderOwner, vali
 //Flag route
 const flagBaseUrl = '/api/v1/flag';
 router.post(`${flagBaseUrl}`, isTokenValid, validateFlag, isCarExist, createFlag)
+
 
 export default router;

--- a/server/test/car.js
+++ b/server/test/car.js
@@ -403,6 +403,30 @@ describe('Car endpoints', function () {
           });
       });
     });
+    describe('Get user cars', () => {
+      it('It should return all users cars', (done) => {
+        chai.request(app)
+          .get(`${baseUrl}/history`)
+          .set('authorization', userToken)
+          .end((err, res) => {
+            expect(res).to.have.status(200);
+            expect(res.body).to.have.property('data');
+            expect(res.body.data).to.be.an('array');
+            done();
+          });
+      });
+      it('It should return no cars found error', (done) => {
+        chai.request(app)
+          .get(`${baseUrl}/history`)
+          .set('authorization', adminToken)
+          .end((err, res) => {
+            expect(res).to.have.status(404);
+            expect(res.body).to.have.property('error');
+            expect(res.body.error).to.be.eql('No cars found');
+      done();
+          });
+      });
+    });
     describe('Filter cars by price', () => {
       it('It should ensure that minPrice is provided', (done) => {
         chai.request(app)


### PR DESCRIPTION
#### What does this PR do?
Implement route for a user to view his Ads history
#### Description of Task to be completed?
Ensure that  a user is able to view his/her Ads history
#### How should this be manually tested?
After cloning this repo, cd into it and on your terminal, enter `npm install` to install all dependencies followed by `npm run dev` to start the dev server.
  * On postman: 
       * Send a `GET` request to the url `localhost/api/v1/car/history`
#### What are the relevant pivotal tracker stories?
#166993545
#### Screenshots
![view ads history](https://user-images.githubusercontent.com/33099347/60374562-0586b280-99fd-11e9-983a-ae37429c98c6.png)
